### PR TITLE
Enable transcript download with YouTube API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ YOUTUBE_API_KEY='Your-API-Key-Here'
 
 (Provide examples on how to use your tool here.)
 
+### Fetching Video Transcripts
+
+This project uses the official YouTube Data API to download caption tracks when
+available. To retrieve a transcript you must authenticate with a Google account
+that has permission to access the captions for the given video. Run:
+
+```bash
+npm run dev -- <videoId>
+```
+
+If captions are found, they will be saved as `<videoId>.srt` in the project
+directory.
+
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/index.js
+++ b/index.js
@@ -1,16 +1,47 @@
-const fetch = (...args) => import('node-fetch').then(({default: f}) => f(...args));
-const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+import { google } from 'googleapis';
+import dotenv from 'dotenv';
+import fs from 'fs';
 
-async function main() {
+dotenv.config();
+
+const videoId = process.argv[2] || 'dQw4w9WgXcQ';
+
+async function fetchTranscript() {
   try {
-    const res = await fetch(url);
-    const html = await res.text();
-    const match = html.match(/<title>(.*?)<\/title>/);
-    const title = match ? match[1] : 'No title found';
-    console.log(title);
+    const auth = new google.auth.GoogleAuth({
+      scopes: ['https://www.googleapis.com/auth/youtube.readonly']
+    });
+    const authClient = await auth.getClient();
+    const youtube = google.youtube({ version: 'v3', auth: authClient });
+
+    const listRes = await youtube.captions.list({
+      part: ['id'],
+      videoId
+    });
+
+    const caption = listRes.data.items?.[0];
+    if (!caption) {
+      console.log('No captions available for this video.');
+      return;
+    }
+
+    const downloadRes = await youtube.captions.download(
+      { id: caption.id, tfmt: 'srt' },
+      { responseType: 'stream' }
+    );
+
+    const dest = fs.createWriteStream(`${videoId}.srt`);
+    await new Promise((resolve, reject) => {
+      downloadRes.data
+        .on('end', resolve)
+        .on('error', reject)
+        .pipe(dest);
+    });
+
+    console.log(`Transcript saved to ${videoId}.srt`);
   } catch (err) {
-    console.error(err);
+    console.error('Failed to fetch transcript:', err.message);
   }
 }
 
-main(); 
+fetchTranscript();

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "type": "module",
   "dependencies": {
-    "node-fetch": "^3.0.0"
+    "node-fetch": "^3.0.0",
+    "googleapis": "^133.0.0",
+    "dotenv": "^16.0.0"
   },
   "scripts": {
     "dev": "node index.js"


### PR DESCRIPTION
## Summary
- add `googleapis` and `dotenv`
- use official API to fetch and save transcripts
- document transcript usage in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*
- `npm run dev` *(fails: cannot find module 'googleapis')*

------
https://chatgpt.com/codex/tasks/task_e_68568232e42c83289dde4c03806f2d57